### PR TITLE
Move to kramdown from redcarpet. 

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,1 @@
-markdown: redcarpet
+markdown: kramdown


### PR DESCRIPTION
Gem `github-pages` does not install `redcarpet` anymore. So, we use `kramdoown` instead.
