### PR TITLE
https:// love for README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@
 
 The Repository for the FirstTimersOnly movement in Open Source. We want projects to reserve some issues for newbies. The real stuff is on the [gh-pages](https://github.com/shanselman/firsttimersonly/tree/gh-pages) branch, so go over there.
 
-http://www.firsttimersonly.com/
+https://www.firsttimersonly.com/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FirstTimersOnly
 
-[![first-timers-only](http://img.shields.io/badge/first--timers--only-friendly-blue.svg)](http://www.firsttimersonly.com/)
+[![first-timers-only](https://img.shields.io/badge/first--timers--only-friendly-blue.svg)](https://www.firsttimersonly.com/)
 [![GitHub issues](https://img.shields.io/github/issues/shanselman/firsttimersonly.svg?maxAge=2592000)](https://github.com/shanselman/firsttimersonly/issues)
 
 


### PR DESCRIPTION
Pared with #44 which fixes up https://www.firsttimersonly.com/ mixed content warnings, this links to and changes the badge as a canonical example.

Note: I'd recommend forcing redirects to `https://` in the GitHub pages settings after this is merged in!